### PR TITLE
Adding support for JSON comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nx-electron",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1633,6 +1633,13 @@
         "inquirer": "^6.3.1",
         "minimist": "^1.2.0",
         "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        }
       }
     },
     "@nrwl/workspace": {
@@ -1664,6 +1671,11 @@
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
           "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -11575,6 +11587,13 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        }
       }
     },
     "rcedit": {
@@ -12866,9 +12885,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "strip-outer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "license-webpack-plugin": "^2.2.0",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.19",
+    "strip-json-comments": "^3.1.1",
     "terser-webpack-plugin": "^3.0.6",
     "tree-kill": "^1.2.2",
     "ts-loader": "^7.0.5",

--- a/src/builders/make/make.impl.ts
+++ b/src/builders/make/make.impl.ts
@@ -13,6 +13,8 @@ import { Observable, from, of } from 'rxjs';
 import { map, concatMap, catchError } from 'rxjs/operators';
 import { platform } from 'os';
 
+import stripJsonComments from 'strip-json-comments';
+
 try {
   require('dotenv').config();
 } catch (e) {}
@@ -157,7 +159,7 @@ function mergePresetOptions(options: MakeElectronBuilderOptions): MakeElectronBu
 
   if (statSync(externalOptionsPath).isFile()) {
     const rawData = readFileSync(externalOptionsPath, 'utf8')
-    const externalOptions = JSON.parse(rawData);
+    const externalOptions = JSON.parse(stripJsonComments(rawData));
     options = Object.assign(options, externalOptions);
   }
 

--- a/src/builders/package/package.impl.ts
+++ b/src/builders/package/package.impl.ts
@@ -16,6 +16,8 @@ import { normalizePackagingOptions } from '../../utils/normalize';
 import { Observable, from, of } from 'rxjs';
 import { map, concatMap, catchError } from 'rxjs/operators';
 
+import stripJsonComments from 'strip-json-comments';
+
 try {
   require('dotenv').config();
 } catch (e) {}
@@ -93,7 +95,7 @@ function mergePresetOptions(options: PackageElectronBuilderOptions): PackageElec
 
   if (statSync(externalOptionsPath).isFile()) {
     const rawData = readFileSync(externalOptionsPath, 'utf8')
-    const externalOptions = JSON.parse(rawData);
+    const externalOptions = JSON.parse(stripJsonComments(rawData));
     options = Object.assign(normalizeIgnoreOptions(options), normalizeIgnoreOptions(externalOptions));
   }
 


### PR DESCRIPTION
I thought it would be nice to support the ability to have comments in the JSON files for maker and builder settings (maker.options.json and packager.options.json). Then these files could even be updated to have some headers that help clarify what they are for. 

While we're on the topic, I also think it feels odd to have those options files under root/src/app/options, since they're not the source code but rather a configuration on how the source should be build. They seem to be peers of tsconfig and the like. What about under root/electron-options? Just a suggestion.

Final notes:
- I'm not sure about the nx-electron version bump in package-lock.json.
- If we wanted to stick with strip-json-comments v2.0.1 to stay consistent with what's already in Nx and avoid the extra dependency (although it's like 6kB unzipped), I'd be ok with that too. 