### PR TITLE
Update electron and fix deprecated node integration flag

### DIFF
--- a/src/schematics/application/files/app/src/app/app.ts__tmpl__
+++ b/src/schematics/application/files/app/src/app/app.ts__tmpl__
@@ -62,7 +62,7 @@ export default class App {
 
         // Create the browser window.
         App.mainWindow = new BrowserWindow({ width: width, height: height, show: false, webPreferences: {
-                nodeIntegration: true,
+                contextIsolation: true,
                 backgroundThrottling: false
             }
         });

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,7 +1,7 @@
-export const nxVersion = '^10.3.0';
-export const nxElectronVersion = '^9.0.0';
-export const electronVersion = '^9.3.2';
-export const electronPackagerVersion = '^14.2.0';
-export const electronBuilderVersion = '^22.9.1';
-export const rimrafVersion = '^3.0.0';
-export const exitZeroVersion = '^1.0.1';
+export const nxVersion = "^10.3.0";
+export const nxElectronVersion = "^9.0.0";
+export const electronVersion = "^11.0.3";
+export const electronPackagerVersion = "^14.2.0";
+export const electronBuilderVersion = "^22.9.1";
+export const rimrafVersion = "^3.0.0";
+export const exitZeroVersion = "^1.0.1";

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,7 +1,7 @@
-export const nxVersion = "^10.3.0";
-export const nxElectronVersion = "^9.0.0";
-export const electronVersion = "^11.0.3";
-export const electronPackagerVersion = "^14.2.0";
-export const electronBuilderVersion = "^22.9.1";
-export const rimrafVersion = "^3.0.0";
-export const exitZeroVersion = "^1.0.1";
+export const nxVersion = '^10.3.0';
+export const nxElectronVersion = '^9.0.0';
+export const electronVersion = '^11.0.3';
+export const electronPackagerVersion = '^14.2.0';
+export const electronBuilderVersion = '^22.9.1';
+export const rimrafVersion = '^3.0.0';
+export const exitZeroVersion = '^1.0.1';


### PR DESCRIPTION
This PR will update electron to the latest stable version (> 11.0.0) and replace the deprecated node integration flag with context isolation as recommended in https://github.com/electron/electron/issues/23506