### PR TITLE
Add electron event api integration via preload script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 <div align="center">
 
 # Nx Electron
+
 Electron builders and schematics for Nrwl Nx platform.
 
 [![licence](https://img.shields.io/github/license/bennymeg/nx-electron.svg)](https://github.com/bennymeg/nx-electron/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/nx-electron.svg)](https://www.npmjs.com/package/nx-electron)
 [![Dependencies status](https://david-dm.org/bennymeg/nx-electron/status.svg)](https://david-dm.org/bennymeg/nx-electron)
 ![Downloads](https://img.shields.io/npm/dt/nx-electron)
+
 <!-- [![github version](https://img.shields.io/github/package-json/v/badges/shields.svg)](https://github.com/bennymeg/nx-electron) -->
 <!-- ![GitHub repository size in bytes](https://img.shields.io/github/languages/code-size/badges/shields.svg) -->
 
@@ -19,6 +21,7 @@ Electron builders and schematics for Nrwl Nx platform.
 # Features
 
 Nx Electron provides a set of power ups on [Nx](https://nx.dev) for developing cross platform desktop apps using [Electron](https://electronjs.org/).
+
 - **Schematics**: Provides schematics for developing cross platform apps in a mono repo environment.
 - **Typescript**: Uses Typescript to help reduce errors, and create more structured code.
 - **Obfuscation**: Since Electron are used on the client machines, nx-electron obfuscates you code (and only it).
@@ -33,9 +36,11 @@ Nx Electron provides a set of power ups on [Nx](https://nx.dev) for developing c
 ## Prerequisite
 
 This module is based on Nx, you will need to [set up an Nx workspace](https://nx.dev/web/getting-started/getting-started) before you can use nx-electron.
+
 ```bash
 npx create-nx-workspace@latest
 ```
+
 You should also create a frontend project in you workspace (in any nx supported framework you like) for you electron app.
 
 ## Installation
@@ -49,6 +54,7 @@ npm install -D nx-electron
 ```bash
 nx g nx-electron:app <electron-app-name> --frontendProject=<frontend-app-name>
 ```
+
 **NOTE:** You should add a frontend project to you workspace prior to invoking this command.
 
 **NOTE:** On certain frontend platforms (such as Angular, React, etc...) it is important to change the baseHref field to "./", and use the hash strategy on the router in order for it to work well with electron. Further details can be found [here](https://github.com/bennymeg/nx-electron/issues/18#issuecomment-616982776).
@@ -83,10 +89,13 @@ The [options](https://www.electron.build/configuration/configuration) that can b
 It is possible to configure all the making that are describes above in _`.\apps\<electron-app-name>\src\app\options\maker.options.json`_.
 **Notice:** the option you define at this file will override the options you pass manually via the command line or choose via the angular console.
 
-## Migrating Electron Application ##
+## Migrating Electron Application
+
 You can find detailed information in the following articles:
+
 - [v8.0.0](https://github.com/bennymeg/nx-electron/blob/master/docs/migration/migrating.v8.md)
 - [v9.0.0](https://github.com/bennymeg/nx-electron/blob/master/docs/migration/migrating.v9.md)
+- [v10.0.0](https://github.com/bennymeg/nx-electron/blob/master/docs/migration/migrating.v10.md)
 
 ## Testing Electron Application
 
@@ -97,6 +106,7 @@ You can find detailed information in the following articles:
 - Follow [this instructions](https://github.com/bennymeg/nx-electron/blob/master/docs/debugging.md) in order to configure the debugger your IDE.
 
 ## Minimal Project Structure
+
 Regardless of what framework you chose, the resulting file tree will look like this:
 
 ```treeview
@@ -113,27 +123,28 @@ Regardless of what framework you chose, the resulting file tree will look like t
 └── tslint.json
 ```
 
-<!-- ## Documentation ##  
-- 👨🏼‍💻 [API](https://github.com/bennymeg/nx-electron/blob/master/docs/API.md),  
-- 👩🏼‍🏫 [Examples](https://github.com/bennymeg/nx-electron/blob/master/docs/examples),  
-- 📜 [Change log](https://github.com/bennymeg/nx-electron/blob/master/docs/CHANGELOG.md),  
+<!-- ## Documentation ##
+- 👨🏼‍💻 [API](https://github.com/bennymeg/nx-electron/blob/master/docs/API.md),
+- 👩🏼‍🏫 [Examples](https://github.com/bennymeg/nx-electron/blob/master/docs/examples),
+- 📜 [Change log](https://github.com/bennymeg/nx-electron/blob/master/docs/CHANGELOG.md),
 - 🖋 [Licence](https://github.com/bennymeg/nx-electron/blob/master/LICENSE) -->
 
-## Support ##
+## Support
+
 If you're having any problem, please [raise an issue](https://github.com/bennymeg/nx-electron/issues/new) on GitHub and we'll be happy to help.
 
-## Contribute ##
+## Contribute
 
 Before submitting a pull request, please make sure that you include tests and lints runs without any warnings.
 
 - 👾 [Issue Tracker](https://github.com/bennymeg/nx-electron/issues),
 - 📦 [Source Code](https://github.com/bennymeg/nx-electron/)
 
-## Versioning ##
+## Versioning
 
 This repository follows the semantic versioning rules while adhering to Nx and Angular version scheme.
 
-## Attribution ## 
+## Attribution
 
 This project is highly inspired by (and dependent on) Nrwl [Nx](https://nx.dev) platform.
 Under the hood, we use [Electron Packager](https://github.com/electron/electron-packager) to package the electron application and [Electron Builder](https://github.com/electron-userland/electron-builder) to make executables.

--- a/docs/migration/migrating.v10.md
+++ b/docs/migration/migrating.v10.md
@@ -1,0 +1,26 @@
+# Migrating To Version 10.0.0
+
+**1.** Add folder and file `.\apps\<electron-app-name>\src\app\api\preload.ts` with the following contents:
+
+```typescript
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electron', {
+  getAppVersion: () => ipcRenderer.invoke('get-app-version'),
+  platform: process.platform
+});
+```
+
+**2.** Update file `.\apps\<electron-app-name>\src\app\app.ts` to include preload entry:
+
+```typescript
+...
+
+webPreferences: {
+    contextIsolation: true,
+    backgroundThrottling: true,
+    preload: join(__dirname, 'preload.js')
+}
+
+...
+```

--- a/src/builders/build/build.impl.ts
+++ b/src/builders/build/build.impl.ts
@@ -1,15 +1,15 @@
+import { join, resolve } from 'path';
+import { from, Observable } from 'rxjs';
+import { concatMap, map } from 'rxjs/operators';
+
 import { BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { BuildResult, runWebpack } from '@angular-devkit/build-webpack';
 import { JsonObject } from '@angular-devkit/core';
-import { runWebpack, BuildResult } from '@angular-devkit/build-webpack';
 
-import { getSourceRoot } from '../../utils/workspace';
 import { getElectronWebpackConfig } from '../../utils/electron.config';
-import { BuildBuilderOptions } from '../../utils/types';
 import { normalizeBuildOptions } from '../../utils/normalize';
-
-import { Observable, from } from 'rxjs';
-import { resolve } from 'path';
-import { map, concatMap } from 'rxjs/operators';
+import { BuildBuilderOptions } from '../../utils/types';
+import { getSourceRoot } from '../../utils/workspace';
 
 try {
   require('dotenv').config();
@@ -45,6 +45,7 @@ function run(
           configuration: context.target.configuration
         });
       }
+      config.entry['preload'] = join(options.sourceRoot, 'app/api/preload.ts');
       return config;
     }),
     concatMap(config =>

--- a/src/schematics/application/files/app/src/app/api/preload.ts__tmpl__
+++ b/src/schematics/application/files/app/src/app/api/preload.ts__tmpl__
@@ -1,0 +1,6 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electron', {
+    getAppVersion: () => ipcRenderer.invoke('get-app-version'),
+    platform: process.platform
+});

--- a/src/schematics/application/files/app/src/app/app.ts__tmpl__
+++ b/src/schematics/application/files/app/src/app/app.ts__tmpl__
@@ -63,7 +63,8 @@ export default class App {
         // Create the browser window.
         App.mainWindow = new BrowserWindow({ width: width, height: height, show: false, webPreferences: {
                 contextIsolation: true,
-                backgroundThrottling: false
+                backgroundThrottling: false,
+                preload: join(__dirname, 'preload.js')
             }
         });
         App.mainWindow.setMenu(null);


### PR DESCRIPTION
This PR will allow to securely implement an API integration between renderer and main process via the recommended preload script option. This is necessary for the option `contextIsolation: true` to still access the ipcRenderer on the remote module, however in the recommended more secure way. See https://github.com/electron/electron/blob/master/docs/tutorial/context-isolation.md

As an example the integration with the `get-app-version` event was implemented in `app/api/preload.ts`, which can be invoked in the browser window via `window.electron.getAppVersion()`.

Let me know if you have any questions or would like to work on how this can be implemented.