### PR TITLE
make build scripts cross platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6067,7 +6067,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -6536,6 +6537,12 @@
         "ipaddr.js": "^1.9.0"
       }
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -6660,7 +6667,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
       "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -10317,6 +10325,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -10331,6 +10340,7 @@
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -10340,6 +10350,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -10349,6 +10360,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -10357,13 +10369,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -10372,7 +10386,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11385,6 +11400,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -11966,11 +11990,41 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
+    },
+    "shx": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.3.tgz",
+      "integrity": "sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.4"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -12,19 +12,19 @@
     "compile": "tsc",
     "build": "npm run clear:all && tsc && npm run copy:all && npm run permission",
     "publish": "cd build && npm publish --tag beta",
-    "permission": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command ./scripts/make_build_public.ps1",
+    "permission": "node ./scripts/make_build_public.js",
     "copy:all": "npm run copy:ts && npm run copy:json && npm run copy:readme && npm run copy:licence && npm run copy:ignore",
-    "copy:ts": "xcopy \"src\" \"build/src/\" /F /Y /S",
-    "copy:json": "xcopy \"*.json\" \"build/\" /F /Y",
-    "copy:readme": "xcopy \"README.md\" \"build/\" /F /Y",
-    "copy:licence": "xcopy \"LICENSE\" \"build/\" /F /Y",
-    "copy:ignore": "xcopy \".*ignore\" \"build/\" /F /Y",
+    "copy:ts": "shx cp -rf src build/",
+    "copy:json": "shx cp -rf *.json build/",
+    "copy:readme": "shx cp -rf README.md build/",
+    "copy:licence": "shx cp -rf LICENSE build/",
+    "copy:ignore": "shx cp -rf .*ignore build/",
     "clear:all": "npm run clear:ts && npm run clear:json && npm run clear:readme && npm run clear:licence && npm run clear:ignore",
-    "clear:ts": "rmdir \".\\build\\src\\\" /q /s",
-    "clear:json": "del \".\\build\\*.json\"",
-    "clear:readme": "del \".\\build\\README.md\"",
-    "clear:licence": "del \".\\build\\LICENSE\"",
-    "clear:ignore": "del \".\\build\\.*ignore\""
+    "clear:ts": "shx rm -rf ./build/src",
+    "clear:json": "shx rm -f ./build/*.json",
+    "clear:readme": "shx rm -f ./build/README.md",
+    "clear:licence": "shx rm -f ./build/LICENSE",
+    "clear:ignore": "shx rm -f ./build/.*ignore"
   },
   "repository": {
     "type": "git",
@@ -106,6 +106,7 @@
     "electron": "^9.3.2",
     "jest": "^26.5.3",
     "prettier": "^2.1.2",
+    "shx": "^0.3.3",
     "typescript": "^3.9.7",
     "utf-8-validate": "^5.0.2"
   }

--- a/scripts/make_build_public.js
+++ b/scripts/make_build_public.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { join } = require('path')
+const { writeFileSync } = require('fs')
+const originalPkgJson = require(join(__dirname, '../package.json'))
+const updatedPkgJson = { ...originalPkgJson, private: false }
+writeFileSync(
+  join(__dirname, '../build/package.json'),
+  JSON.stringify(updatedPkgJson, null, 2)
+)

--- a/scripts/make_build_public.ps1
+++ b/scripts/make_build_public.ps1
@@ -1,1 +1,0 @@
-(Get-content package.json) | Foreach-Object {$_ -replace '"private": true,', '"private": false,'} | Set-Content build/package.json


### PR DESCRIPTION
Updated the npm scripts to be cross platform using [shx](https://github.com/shelljs/shx).

Seems to fix https://github.com/bennymeg/nx-electron/issues/66 but I am not exactly sure why.

I don't use windows, so after making the scripts cross platform, and using `yarn link` to test, everything seems to just be working :man_shrugging:

I would give this a quick test on windows though. It *should* work cross platform. But is untested.

