### PR TITLE
Fix(tsconfig): updates extends to nx default

### DIFF
--- a/src/schematics/application/files/app/tsconfig.json
+++ b/src/schematics/application/files/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offset %>tsconfig.json",
+  "extends": "<%= offset %>tsconfig.base.json",
   "compilerOptions": {
     "types": ["node"]
   },


### PR DESCRIPTION
Updates the `extends` property to target the default workspace filename: "tsconfig.base.json".