### PR TITLE
Update to indicate steps 2 & 3 are optional

### DIFF
--- a/docs/migration/migrating.v10.md
+++ b/docs/migration/migrating.v10.md
@@ -20,8 +20,7 @@
     },
 ```
 
-### The steps below are only necessary if you are using contextIsolation in the BrowserWindow
---> Read more about Electron Context Isolation [here](https://www.electronjs.org/docs/tutorial/context-isolation).
+> **💡  The steps below are only necessary if you are using [Context Isolation](https://www.electronjs.org/docs/tutorial/context-isolation).**
 
 **2.** Add folder and file `.\apps\<electron-app-name>\src\app\api\preload.ts` with the following contents:
 

--- a/docs/migration/migrating.v10.md
+++ b/docs/migration/migrating.v10.md
@@ -20,6 +20,9 @@
     },
 ```
 
+### The steps below are only necessary if you are using contextIsolation in the BrowserWindow
+--> Read more about Electron Context Isolation [here](https://www.electronjs.org/docs/tutorial/context-isolation).
+
 **2.** Add folder and file `.\apps\<electron-app-name>\src\app\api\preload.ts` with the following contents:
 
 ```typescript
@@ -31,7 +34,7 @@ contextBridge.exposeInMainWorld('electron', {
 });
 ```
 
-**3.** Update file `.\apps\<electron-app-name>\src\app\app.ts` to include preload entry:
+**3.** Update file `.\apps\<electron-app-name>\src\app\app.ts` to include preload entry and use contextIsolation:
 
 ```typescript
 ...


### PR DESCRIPTION
I do not believe steps 2 and 3 are actually required when upgrading to v10 of nx-electron. They are only necessary if you are using `contextIsolation=true` in webPreferences. Although that is the recommended security posture from Electron, it is not required and is overkill for some applications.