### PR TITLE
fix: allow optional assets in build config

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -97,7 +97,7 @@ export function getBaseWebpackPartial(options: BuildBuilderOptions): Configurati
   }
 
   // process asset entries
-  if (options.assets) {
+  if (options.assets && options.assets.length >= 1) {
     const copyWebpackPluginPatterns = options.assets.map((asset: any) => {
       return {
         context: asset.input,


### PR DESCRIPTION
Fixes https://github.com/bennymeg/nx-electron/issues/82

Notes about testing:

I tried to follow the guide: https://github.com/bennymeg/nx-electron/blob/master/CONTRIBUTING.md

I built using `npm run build` and tested using `npm link` with my `nx-electron-test` repository, it worked fine.

`npm run test` seemed to have some errors but as far as I can tell they are unrelated:

[test2.txt](https://github.com/bennymeg/nx-electron/files/6128071/test2.txt)

`npm run lint` seems to scan all  of node_modules, scripts, build folder by default, so I wonder if this script is in active use?

I added the following .jshintignore file:

```
node_modules/
scripts/
build/
```

and then I got 0 remaining lint errors.