### PR TITLE
fix build on windows

### DIFF
--- a/src/builders/build/build.impl.ts
+++ b/src/builders/build/build.impl.ts
@@ -71,7 +71,7 @@ function run( options: JsonObject & BuildElectronBuilderOptions, context: Builde
           configuration: context.target.configuration
         });
       }
-      config.entry['preload'] = join(options.sourceRoot, 'app/api/preload.ts');
+      config.entry['preload'] = join(options.root, options.sourceRoot, 'app/api/preload.ts');
       return config;
     }),
     concatMap(config =>


### PR DESCRIPTION
ERROR in Entry module not found: Error: Can't resolve 'apps\123456\src\app\api\preload.ts' in 'C:\develop\123456'