### PR TITLE
feat(package): add option for overriding make options file

### DIFF
--- a/src/builders/package/package.impl.ts
+++ b/src/builders/package/package.impl.ts
@@ -32,6 +32,7 @@ export interface PackageElectronBuilderOptions extends Configuration {
   sourcePath: string;
   outputPath: string;
   publishPolicy?: PublishOptions["publish"];
+  makerOptionsPath?: string;
 }
 
 export interface PackageElectronBuilderOutput extends BuilderOutput {
@@ -164,6 +165,7 @@ function _createConfigFromOptions(options: PackageElectronBuilderOptions, baseCo
   delete config["publishPolicy"];
   delete config.sourcePath;
   delete config.outputPath;
+  delete config["makerOptionsPath"];
 
   return config;
 }
@@ -182,7 +184,10 @@ function _normalizeBuilderOptions(targets: Map<Platform, Map<Arch, string[]>>, c
 
 function mergePresetOptions(options: PackageElectronBuilderOptions): PackageElectronBuilderOptions {
   // load preset options file
-  const externalOptionsPath: string = join(options.root, options['sourceRoot'], 'app', 'options', 'maker.options.json');
+  let externalOptionsPath: string = join(options.root, options['sourceRoot'], 'app', 'options', 'maker.options.json');
+  if (options.makerOptionsPath) {
+    externalOptionsPath = options.makerOptionsPath
+  }
 
   if (statSync(externalOptionsPath).isFile()) {
     const rawData = readFileSync(externalOptionsPath, 'utf8')

--- a/src/builders/package/schema.json
+++ b/src/builders/package/schema.json
@@ -57,6 +57,10 @@
       "type": "string",
       "enum": ["onTag", "onTagOrDraft", "always", "never"],
       "description": "Package publish policy."
+    },
+    "makerOptionsPath": {
+      "type": "string",
+      "description": "Overrides the {sourceRoot}/app/options/maker.options.json path."
     }
   },
   "required": ["name", "frontendProject"]


### PR DESCRIPTION
Sometimes the make options should have different config. e.g., environment or alfa/beta testing icons

Target branch changed to master.