### PR TITLE
Fix for preload webpack entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Nx Electron provides a set of power ups on [Nx](https://nx.dev) for developing c
 - **Typescript**: Uses Typescript to help reduce errors, and create more structured code.
 - **Obfuscation**: Since Electron are used on the client machines, nx-electron obfuscates you code (and only it).
 - **Minimization**: Electron apps tend to be quite large, hence we use webpack to bundle, and minimize to code.
-- **Live Update**: Provides continuos live reload for your backend code.
+- **Live Update**: Provides continuous live reload for your backend code.
 - **Event Templates**: Provides templates for common events like squirrel setup events, auto update events and IPC events.
 - **Packaging**: Packages your frontend and backend webpack bundles into single electron package.
 - **Making**: Makes your frontend and backend webpack bundles into single executable.

--- a/e2e/nx-electron-e2e/jest.config.js
+++ b/e2e/nx-electron-e2e/jest.config.js
@@ -10,5 +10,5 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/e2e\nx-electron-e2e',
+  coverageDirectory: '../../coverage/e2e/nx-electron-e2e',
 };

--- a/e2e/nx-electron-e2e/project.json
+++ b/e2e/nx-electron-e2e/project.json
@@ -1,7 +1,7 @@
 {
-  "root": "e2e\\nx-electron-e2e",
+  "root": "e2e/nx-electron-e2e",
   "projectType": "application",
-  "sourceRoot": "e2e\\nx-electron-e2e/src",
+  "sourceRoot": "e2e/nx-electron-e2e/src",
   "targets": {
     "e2e": {
       "executor": "@nrwl/nx-plugin:e2e",

--- a/packages/nx-electron/README.md
+++ b/packages/nx-electron/README.md
@@ -24,7 +24,7 @@ Nx Electron provides a set of power ups on [Nx](https://nx.dev) for developing c
 - **Typescript**: Uses Typescript to help reduce errors, and create more structured code.
 - **Obfuscation**: Since Electron are used on the client machines, nx-electron obfuscates you code (and only it).
 - **Minimization**: Electron apps tend to be quite large, hence we use webpack to bundle, and minimize to code.
-- **Live Update**: Provides continuos live reload for your backend code.
+- **Live Update**: Provides continuous live reload for your backend code.
 - **Event Templates**: Provides templates for common events like squirrel setup events, auto update events and IPC events.
 - **Packaging**: Packages your frontend and backend webpack bundles into single electron package.
 - **Making**: Makes your frontend and backend webpack bundles into single executable.

--- a/packages/nx-electron/src/executors/build/executor.ts
+++ b/packages/nx-electron/src/executors/build/executor.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, parse, resolve } from 'path';
 import { map, tap } from 'rxjs/operators';
 import { eachValueFrom } from 'rxjs-for-await';
 import { readdirSync } from 'fs';
@@ -44,7 +44,7 @@ export function executor(rawOptions: BuildElectronBuilderOptions, context: Execu
   const projGraph = readCachedProjectGraph();
 
   if (!normalizedOptions.buildLibsFromSource) {
-    const { target, dependencies } = 
+    const { target, dependencies } =
       calculateProjectDependencies(projGraph, context.root, context.projectName, context.targetName, context.configurationName);
 
     normalizedOptions.tsConfig = createTmpTsConfig(normalizedOptions.tsConfig, context.root, target.data.root, dependencies);
@@ -70,7 +70,7 @@ export function executor(rawOptions: BuildElectronBuilderOptions, context: Execu
     const preloadFilesDirectory = join(normalizedOptions.sourceRoot, 'app/api');
     readdirSync(preloadFilesDirectory, { withFileTypes: true })
       .filter(entry => entry.isFile() && entry.name.match(/(.+[.])?preload.ts/))
-      .forEach(entry => config.entry[entry.name] = join(preloadFilesDirectory, entry.name));
+      .forEach(entry => config.entry[parse(entry.name).name] = join(preloadFilesDirectory, entry.name));
   } catch (error) {
     console.warn('Failed to load preload scripts');
   }

--- a/workspace.json
+++ b/workspace.json
@@ -2,6 +2,6 @@
   "version": 2,
   "projects": {
     "nx-electron": "packages/nx-electron",
-    "nx-electron-e2e": "e2e\\nx-electron-e2e"
+    "nx-electron-e2e": "e2e/nx-electron-e2e"
   }
 }


### PR DESCRIPTION
The current webpack configuration is including the '.ts' file extension in the entry chunk name.  This is causing the compiled filename to look like 'main.preload.ts.js'

This might also fix #163