### PR TITLE
Resolve issues with nx-electron generator unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "nx run nx-electron:build",
     "link": "npm link ./dist/packages/nx-electron/",
     "test": "nx run nx-electron:test",
+    "test:watch": "nx run nx-electron:test -- --watch",
     "lint": "nx run nx-electron:lint",
     "publish": "cd dist/packages/nx-electron && npm publish",
     "publish:alpha": "cd dist/packages/nx-electron && npm publish --tag alpha",

--- a/packages/nx-electron/package-lock.json
+++ b/packages/nx-electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nx-electron",
-  "version": "16.0.0-alpha.1",
+  "version": "16.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nx-electron",
-      "version": "16.0.0-alpha.1",
+      "version": "16.0.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "copy-webpack-plugin": "^11.0.0",

--- a/packages/nx-electron/src/executors/build/executor.compat.ts
+++ b/packages/nx-electron/src/executors/build/executor.compat.ts
@@ -1,12 +1,5 @@
-import { convertNxExecutor, ExecutorContext } from '@nx/devkit';
+import { convertNxExecutor } from '@nx/devkit';
 
 import executor from './executor';
 
-function executorAdapter(
-  options: any,
-  context: ExecutorContext
-): Promise<{ success: boolean }> | AsyncIterableIterator<{ success: boolean }> {
-  return executor(options, context);
-}
-
-export default convertNxExecutor(executorAdapter);
+export default convertNxExecutor(executor);

--- a/packages/nx-electron/src/executors/build/executor.spec.ts
+++ b/packages/nx-electron/src/executors/build/executor.spec.ts
@@ -7,13 +7,15 @@ jest.mock('../../utils/run-webpack', () => ({
   runWebpack: jest.fn(),
 }));
 
+jest.mock('@nx/workspace/src/core/project-graph');
+
 import { runWebpack } from '../../utils/run-webpack';
 
 describe('ElectronBuildBuilder', () => {
   let context: ExecutorContext;
   let options: BuildElectronBuilderOptions;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     jest
       .spyOn(projectGraph, 'readCachedProjectGraph')
       .mockReturnValue({} as ProjectGraph);
@@ -39,7 +41,7 @@ describe('ElectronBuildBuilder', () => {
 
     options = {
       main: 'apps/electron-app/src/main.ts',
-      tsConfig: 'apps/electron-app/tsconfig.ts',
+      tsConfig: 'apps/electron-app/tsconfig.json',
       outputPath: 'dist/apps/electron-app',
       externalDependencies: 'all',
       implicitDependencies: [],
@@ -48,63 +50,60 @@ describe('ElectronBuildBuilder', () => {
       assets: [],
       statsJson: false,
     };
+  });
 
-    afterEach(() => jest.clearAllMocks());
+  afterEach(() => jest.clearAllMocks());
 
-    it('should call webpack', async () => {
-      await executor(options, context).next();
+  it('should call webpack', async () => {
+    await executor(options, context).next();
 
-      expect(runWebpack).toHaveBeenCalledWith(
-        expect.objectContaining({
-          output: expect.objectContaining({
-            filename: 'main.js',
-            libraryTarget: 'commonjs',
-            path: '/root/dist/apps/electron-app',
-          }),
-        })
+    expect(runWebpack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expect.objectContaining({
+          filename: 'main.js',
+          libraryTarget: 'commonjs',
+          path: '/root/dist/apps/electron-app',
+        }),
+      })
+    );
+  });
+
+  it('should use outputFileName if passed in', async () => {
+    await executor({ ...options, outputFileName: 'index.js' }, context).next();
+
+    expect(runWebpack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expect.objectContaining({
+          filename: 'index.js',
+          libraryTarget: 'commonjs',
+          path: '/root/dist/apps/wibble',
+        }),
+      })
+    );
+  });
+
+  describe('webpackConfig', () => {
+    it('should handle custom path', async () => {
+      jest.mock(
+        '/root/config.js',
+        () => (options) => ({ ...options, prop: 'my-val' }),
+        { virtual: true }
       );
-    });
-
-    it('should use outputFileName if passed in', async () => {
       await executor(
-        { ...options, outputFileName: 'index.js' },
+        { ...options, webpackConfig: 'config.js' },
         context
       ).next();
 
       expect(runWebpack).toHaveBeenCalledWith(
         expect.objectContaining({
           output: expect.objectContaining({
-            filename: 'index.js',
+            filename: 'main.js',
             libraryTarget: 'commonjs',
             path: '/root/dist/apps/wibble',
           }),
+          prop: 'my-val',
         })
       );
-    });
-
-    describe('webpackConfig', () => {
-      it('should handle custom path', async () => {
-        jest.mock(
-          '/root/config.js',
-          () => (options) => ({ ...options, prop: 'my-val' }),
-          { virtual: true }
-        );
-        await executor(
-          { ...options, webpackConfig: 'config.js' },
-          context
-        ).next();
-
-        expect(runWebpack).toHaveBeenCalledWith(
-          expect.objectContaining({
-            output: expect.objectContaining({
-              filename: 'main.js',
-              libraryTarget: 'commonjs',
-              path: '/root/dist/apps/wibble',
-            }),
-            prop: 'my-val',
-          })
-        );
-      });
     });
   });
 });

--- a/packages/nx-electron/src/executors/build/executor.ts
+++ b/packages/nx-electron/src/executors/build/executor.ts
@@ -1,5 +1,6 @@
 import { join, parse, resolve } from 'path';
 import { map, tap } from 'rxjs/operators';
+// eslint-disable-next-line @nx/enforce-module-boundaries
 import { eachValueFrom } from 'rxjs-for-await';
 import { readdirSync } from 'fs';
 
@@ -17,7 +18,6 @@ import { normalizeBuildOptions } from '../../utils/normalize';
 import { BuildBuilderOptions } from '../../utils/types';
 import { getSourceRoot } from '../../utils/workspace';
 import { MAIN_OUTPUT_FILENAME } from '../../utils/config';
-import { generatePackageJson } from '../../utils/generate-package-json';
 import { createPackageJson } from '@nrwl/js';
 
 export type ElectronBuildEvent = {
@@ -81,7 +81,7 @@ export function executor(
   }
 
   if (normalizedOptions.generatePackageJson) {
-    createPackageJson(context.projectName, projGraph, { ...normalizedOptions, 'isProduction': true })
+    createPackageJson(context.projectName, projGraph as any, { ...normalizedOptions, 'isProduction': true })
   }
 
   let config = getElectronWebpackConfig(normalizedOptions);

--- a/packages/nx-electron/src/executors/build/executor.ts
+++ b/packages/nx-electron/src/executors/build/executor.ts
@@ -18,7 +18,7 @@ import { normalizeBuildOptions } from '../../utils/normalize';
 import { BuildBuilderOptions } from '../../utils/types';
 import { getSourceRoot } from '../../utils/workspace';
 import { MAIN_OUTPUT_FILENAME } from '../../utils/config';
-import { createPackageJson } from '@nrwl/js';
+import { createPackageJson } from '@nx/js';
 
 export type ElectronBuildEvent = {
   outfile: string;

--- a/packages/nx-electron/src/generators/nx-electron/generator.ts
+++ b/packages/nx-electron/src/generators/nx-electron/generator.ts
@@ -113,8 +113,7 @@ function addProject(tree: Tree, options: NormalizedSchema) {
   addProjectConfiguration(
     tree,
     options.name,
-    project,
-    options.standaloneConfig
+    project
   );
 
   const nxJsonConfiguration = readNxJson(tree);
@@ -191,7 +190,7 @@ function addProxy(tree: Tree, options: NormalizedSchema) {
   }
 }
 
-export async function addLintingToApplication(
+async function addLintingToApplication(
   tree: Tree,
   options: NormalizedSchema
 ): Promise<GeneratorCallback> {

--- a/packages/nx-electron/src/generators/nx-electron/schema.d.ts
+++ b/packages/nx-electron/src/generators/nx-electron/schema.d.ts
@@ -12,5 +12,4 @@ export interface Schema {
   linter: Linter;
   tags?: string;
   setParserOptionsProject?: boolean;
-  standaloneConfig?: boolean;
 }

--- a/packages/nx-electron/src/generators/nx-electron/schema.json
+++ b/packages/nx-electron/src/generators/nx-electron/schema.json
@@ -78,10 +78,6 @@
       "type": "boolean",
       "description": "Whether or not to configure the ESLint \"parserOptions.project\" option. We do not do this by default for lint performance reasons.",
       "default": false
-    },
-    "standaloneConfig": {
-      "description": "Split the project configuration into <projectRoot>/project.json rather than including it inside workspace.json",
-      "type": "boolean"
     }
   },
   "required": [

--- a/packages/nx-electron/src/migrations/update-12-0-0/remove-deprecated-options.spec.ts
+++ b/packages/nx-electron/src/migrations/update-12-0-0/remove-deprecated-options.spec.ts
@@ -8,25 +8,20 @@ describe('Migration: Remove deprecated options', () => {
     const tree = createTreeWithEmptyWorkspace();
 
     tree.write(
-      'workspace.json',
+      'project.json',
       JSON.stringify({
-        version: 2,
-        projects: {
-          myapp: {
-            root: 'apps/myapp',
-            sourceRoot: 'apps/myapp/src',
-            projectType: 'application',
-            targets: {
-              build: {
-                executor: 'nx-electron:build',
-                options: {
-                  showCircularDependencies: false,
-                },
-                configurations: {
-                  production: {
-                    showCircularDependencies: true,
-                  },
-                },
+        name: 'electron-app',
+        sourceRoot: 'apps/myapp/src',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: 'nx-electron:build',
+            options: {
+              showCircularDependencies: false,
+            },
+            configurations: {
+              production: {
+                showCircularDependencies: true,
               },
             },
           },
@@ -36,21 +31,17 @@ describe('Migration: Remove deprecated options', () => {
 
     await subject(tree);
 
-    expect(readJson(tree, 'workspace.json')).toEqual({
-      version: 2,
-      projects: {
-        myapp: {
-          root: 'apps/myapp',
-          sourceRoot: 'apps/myapp/src',
-          projectType: 'application',
-          targets: {
-            build: {
-              executor: 'nx-electron:build',
-              options: {},
-              configurations: {
-                production: {},
-              },
-            },
+    expect(readJson(tree, 'project.json')).toEqual({
+      $schema: 'node_modules/nx/schemas/project-schema.json',
+      name: 'electron-app',
+      sourceRoot: 'apps/myapp/src',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: 'nx-electron:build',
+          options: {},
+          configurations: {
+            production: {},
           },
         },
       },


### PR DESCRIPTION
Hi @bennymeg 

Whilst doing my last PR I noticed most the unit tests were all falling over so I thought I'd try put a dent in some of them.

This PR mainly sorts out generator.spec.ts for the nx-electron generator. - Be sure to expand it as GH has collapsed the file changes.
The rest of the changes are either formatting or attempting to make a dent in the other specs without much luck. 
Ideally the next big stride would be to get the executor tests all passing but I wasn't able to crack mocking the right bits.

Hopefully the test cases I've added should help clarify what parts of the generator are/aren't working anymore.

<img width="654" alt="Screenshot 2023-08-02 at 09 56 37" src="https://github.com/bennymeg/nx-electron/assets/12980659/15abe327-cd34-4043-80ac-e5c14f5056e1">


### **FYI**

During this refactor I noticed that the `tags` option currently isn't working. I've included the test case commented out for when we want to re-implement this functionality.

Also when [merging from develop yesterday]( https://github.com/bennymeg/nx-electron/commit/5c8ff74e251e0650a8297ab4366477bcebf09dfa#diff-93c7820396c392edb294603f4f771d391976932ad39fc87efeb31aba09bac7d3) and changing the sourceRoot. It seems to have broken my :make command on my test app. I've gotten around it by passing --sourceRoot=dist/apps for now 👍 Just thought I'd highlight