### PR TITLE
task(executor): switch default source back to apps

### DIFF
--- a/packages/nx-electron/src/executors/package/schema.json
+++ b/packages/nx-electron/src/executors/package/schema.json
@@ -33,7 +33,7 @@
     "sourcePath": {
       "type": "string",
       "description": "The full path for the compiled source directory, relative to the current workspace. If this parameter is not supplied, the 'sourcePath' path from angular.json will be used.",
-      "default": "dist/packages"
+      "default": "dist/apps"
     },
     "outputPath": {
       "type": "string",


### PR DESCRIPTION
Hopefully the last issue caused from bits that slipped in from develop after the nx 16 migration.

I'd initially thought that this was just on my project but seems it's everyone.

Resolve issues with the :make command that @alkrobinson experienced in #217 