### PR TITLE
fix(generator): resolve type issue in update events template

### DIFF
--- a/packages/nx-electron/src/generators/nx-electron/files/app/src/app/events/update.events.ts__tmpl__
+++ b/packages/nx-electron/src/generators/nx-electron/files/app/src/app/events/update.events.ts__tmpl__
@@ -1,4 +1,4 @@
-import { app, autoUpdater, dialog } from 'electron';
+import { app, autoUpdater, dialog, MessageBoxOptions } from 'electron';
 import { platform, arch } from 'os';
 import { updateServerUrl } from '../constants';
 import App from '../app';
@@ -28,7 +28,7 @@ export default class UpdateEvents {
 }
 
 autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName, releaseDate) => {
-    const dialogOpts = {
+    const dialogOpts: MessageBoxOptions = {
       type: 'info',
       buttons: ['Restart', 'Later'],
       title: 'Application Update',


### PR DESCRIPTION
Looks like electron updated some of their typings for the dialog type and it wasn't happy accepting a "string".

Adding the type to the dialog options variable sorted it out 👍 

Resolves the issue encountered by @abf7d in #217 