### PR TITLE
[FIX] Relative path of main.preload was being passed leading to a webpack ERROR

### DIFF
--- a/packages/nx-electron/src/executors/build/executor.ts
+++ b/packages/nx-electron/src/executors/build/executor.ts
@@ -100,7 +100,7 @@ export function executor(
       )
       .forEach(
         (entry) =>
-          (config.entry[parse(entry.name).name] = join(
+          (config.entry[parse(entry.name).name] = resolve(
             preloadFilesDirectory,
             entry.name
           ))


### PR DESCRIPTION
BEFORE
======

```
> nx run mailmagnet-app:build

Dirent {
  name: 'main.preload.ts',
  path: 'mailmagnet/app/src/app/api',
  [Symbol(type)]: 1
} {
  entry: {
    main: [
      '/Users/arkadevbanerjee/Desktop/Development/ui-remote/mailmagnet/app/src/main.ts'
    ],
    'main.preload': 'mailmagnet/app/src/app/api/main.preload.ts'
  },
  devtool: 'source-map',
  mode: 'development',
  output: {
    path: '/Users/arkadevbanerjee/Desktop/Development/ui-remote/dist/mailmagnet/app',
    filename: [Function: filename],
    hashFunction: 'xxhash64',
    pathinfo: false,
    libraryTarget: 'commonjs'
  },
  module: { rules: [ [Object] ] },
  resolve: {
    extensions: [ '.ts', '.tsx', '.mjs', '.js', '.jsx' ],
    alias: {},
    plugins: [ [TsconfigPathsPlugin] ],
    mainFields: [ 'es2015', 'module', 'main' ]
  },
  performance: { hints: false },
  plugins: [
    ForkTsCheckerWebpackPlugin { options: [Object] },
    DefinePlugin { definitions: [Object] },
    CopyPlugin { patterns: [Array], options: {} }
  ],
  watch: false,
  watchOptions: { poll: undefined },
  stats: 'normal',
  target: 'electron-main',
  node: false,
  externals: [ [Function (anonymous)] ]
}
asset main.js 11.9 KiB [compared for emit] (name: main) 1 related asset
asset main.preload.js 99 bytes [emitted] (name: main.preload)
asset assets/gitkeep_tmpl_ 13 bytes [compared for emit] [from: mailmagnet/app/src/assets/gitkeep_tmpl_] [copied]
cacheable modules 9.05 KiB
  modules by path ./mailmagnet/app/src/app/ 7.83 KiB
    modules by path ./mailmagnet/app/src/app/events/*.ts 2.97 KiB
      ./mailmagnet/app/src/app/events/squirrel.events.ts 2.2 KiB [built] [code generated]
      ./mailmagnet/app/src/app/events/electron.events.ts 791 bytes [built] [code generated]
    modules by path ./mailmagnet/app/src/app/*.ts 4.85 KiB
      ./mailmagnet/app/src/app/app.ts 4.41 KiB [built] [code generated]
      ./mailmagnet/app/src/app/constants.ts 449 bytes [built] [code generated]
  ./mailmagnet/app/src/main.ts 1.04 KiB [built] [code generated]
  ./mailmagnet/app/src/environments/environment.ts 189 bytes [built] [code generated]
external "electron" 42 bytes [built] [code generated]
external "child_process" 42 bytes [built] [code generated]
external "path" 42 bytes [built] [code generated]
external "url" 42 bytes [built] [code generated]

ERROR in main.preload
Module not found: Error: Can't resolve 'mailmagnet/app/src/app/api/main.preload.ts' in '/Users/arkadevbanerjee/Desktop/Development/ui-remote'
Did you mean './mailmagnet/app/src/app/api/main.preload.ts'?
Requests that should resolve in the current directory need to start with './'.
Requests that start with a name are treated as module requests and resolve within module directories (node_modules).
If changing the source code is not an option there is also a resolve options called 'preferRelative' which tries to resolve these kind of requests in the current directory too.
resolve 'mailmagnet/app/src/app/api/main.preload.ts' in '/Users/arkadevbanerjee/Desktop/Development/ui-remote'
  Parsed request is a module
  using description file: /Users/arkadevbanerjee/Desktop/Development/ui-remote/package.json (relative path: .)
    resolve as module
      looking for modules in /Users/arkadevbanerjee/Desktop/Development/ui-remote/node_modules
        /Users/arkadevbanerjee/Desktop/Development/ui-remote/node_modules/mailmagnet doesn't exist
      /Users/arkadevbanerjee/Desktop/Development/node_modules doesn't exist or is not a directory
      /Users/arkadevbanerjee/Desktop/node_modules doesn't exist or is not a directory
      /Users/arkadevbanerjee/node_modules doesn't exist or is not a directory
      /Users/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory

webpack 5.90.0 compiled with 1 error in 897 ms

 ———————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target build for project mailmagnet-app (2s)
 
    ✖    1/1 failed
    ✔    0/1 succeeded [0 read from cache]
```


AFTER
=====


```
> nx run mailmagnet-app:build

Dirent {
  name: 'main.preload.ts',
  path: 'mailmagnet/app/src/app/api',
  [Symbol(type)]: 1
} {
  entry: {
    main: [
      '/Users/arkadevbanerjee/Desktop/Development/ui-remote/mailmagnet/app/src/main.ts'
    ],
    'main.preload': '/Users/arkadevbanerjee/Desktop/Development/ui-remote/mailmagnet/app/src/app/api/main.preload.ts'
  },
  devtool: 'source-map',
  mode: 'development',
  output: {
    path: '/Users/arkadevbanerjee/Desktop/Development/ui-remote/dist/mailmagnet/app',
    filename: [Function: filename],
    hashFunction: 'xxhash64',
    pathinfo: false,
    libraryTarget: 'commonjs'
  },
  module: { rules: [ [Object] ] },
  resolve: {
    extensions: [ '.ts', '.tsx', '.mjs', '.js', '.jsx' ],
    alias: {},
    plugins: [ [TsconfigPathsPlugin] ],
    mainFields: [ 'es2015', 'module', 'main' ]
  },
  performance: { hints: false },
  plugins: [
    ForkTsCheckerWebpackPlugin { options: [Object] },
    DefinePlugin { definitions: [Object] },
    CopyPlugin { patterns: [Array], options: {} }
  ],
  watch: false,
  watchOptions: { poll: undefined },
  stats: 'normal',
  target: 'electron-main',
  node: false,
  externals: [ [Function (anonymous)] ]
}
asset main.js 11.9 KiB [compared for emit] (name: main) 1 related asset
asset main.preload.js 1.96 KiB [emitted] (name: main.preload) 1 related asset
asset assets/gitkeep_tmpl_ 13 bytes [compared for emit] [from: mailmagnet/app/src/assets/gitkeep_tmpl_] [copied]
cacheable modules 9.33 KiB
  modules by path ./mailmagnet/app/src/app/ 8.11 KiB
    modules by path ./mailmagnet/app/src/app/events/*.ts 2.97 KiB
      ./mailmagnet/app/src/app/events/squirrel.events.ts 2.2 KiB [built] [code generated]
      ./mailmagnet/app/src/app/events/electron.events.ts 791 bytes [built] [code generated]
    modules by path ./mailmagnet/app/src/app/*.ts 4.85 KiB
      ./mailmagnet/app/src/app/app.ts 4.41 KiB [built] [code generated]
      ./mailmagnet/app/src/app/constants.ts 449 bytes [built] [code generated]
    ./mailmagnet/app/src/app/api/main.preload.ts 285 bytes [built] [code generated]
  ./mailmagnet/app/src/main.ts 1.04 KiB [built] [code generated]
  ./mailmagnet/app/src/environments/environment.ts 189 bytes [built] [code generated]
external "electron" 42 bytes [built] [code generated]
external "child_process" 42 bytes [built] [code generated]
external "path" 42 bytes [built] [code generated]
external "url" 42 bytes [built] [code generated]
webpack 5.90.0 compiled successfully in 901 ms

 ———————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target build for project mailmagnet-app (2s)
```