### PR TITLE
Fix build version parsing from extraMetadata

### DIFF
--- a/packages/nx-electron/src/utils/config.ts
+++ b/packages/nx-electron/src/utils/config.ts
@@ -95,8 +95,8 @@ export function getBaseWebpackPartial(
         },
       }),
       new DefinePlugin({
-        __BUILD_VERSION__: 
-          options.extraMetadata?.version || JSON.stringify(require(join(options.root, 'package.json')).version),
+        __BUILD_VERSION__:
+          JSON.stringify(options.extraMetadata?.version || require(join(options.root, 'package.json')).version),
         __BUILD_DATE__: Date.now(),
       }),
     ],


### PR DESCRIPTION
When manually passing a build version using `extraMetadata`, as in:

`nx build my-application --configuration=production --extraMetadata.version='2.0.1'`

and then starting the application, an error like this happens:

<img width="522" alt="Screenshot 2024-06-25 at 14 15 09" src="https://github.com/bennymeg/nx-electron/assets/5260309/ca77baec-f347-4159-8626-08c8937a0a27">

So I propose to fix it by wrapping it with `JSON.stringify()` :)