### PR TITLE
fix(package): fail when a configured copy step source does not exist

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -7,6 +7,19 @@ You can find a detailed description of all of its available options [here](https
 ## CLI options
 The CLI options that can be passed are described [here](https://github.com/bennymeg/nx-electron/blob/master/packages/nx-electron/src/validation/maker.schema.json).
 
+## Copy steps and missing sources
+
+Additional files and assets are included in the artifact via electron-builder's `files`, `extraResources` and `extraFiles` options (the `from` of a `files` entry is resolved relative to `sourcePath`, `extraResources` / `extraFiles` relative to the workspace root). electron-builder itself silently skips a copy step whose `from` does not exist, which would produce a "successful" package that is missing assets.
+
+Nx Electron therefore verifies before packaging that every explicitly configured copy step source (`files` FileSets, `frontendProject`, `extraProjects`, `extraResources`, `extraFiles`) exists and fails the target otherwise. Glob patterns and entries containing `${macro}` expansions are not checked.
+
+To restore the lenient behaviour (only a warning is logged) set `failOnMissingFiles` to `false`, either as target option or inside `maker.options.json`:
+```json
+{
+  "failOnMissingFiles": false
+}
+```
+
 ## Configuring static packaging options
 
 It is possible to configure all the packaging that are describes above in _`.\apps\<electron-app-name>\src\app\options\maker.options.json`_.

--- a/packages/nx-electron/src/executors/package/executor.spec.ts
+++ b/packages/nx-electron/src/executors/package/executor.spec.ts
@@ -1,26 +1,49 @@
-import { ExecutorContext } from '@nx/devkit';
-import { PackageElectronBuilderOptions } from './executor';
+import { ExecutorContext, logger } from '@nx/devkit';
+import { resolve } from 'path';
+import * as fs from 'fs';
+import {
+  PackageElectronBuilderOptions,
+  _createBaseConfig,
+  _createConfigFromOptions,
+  findMissingFileSources,
+  validateFileSources,
+} from './executor';
 
 jest.mock('glob');
 
 jest.mock('fs-extra');
+
+jest.mock('fs', () => {
+  const actualFs = jest.requireActual('fs');
+  return {
+    ...actualFs,
+    existsSync: jest.fn(actualFs.existsSync),
+  };
+});
+
+function makeOptions(
+  overrides: Partial<PackageElectronBuilderOptions> = {}
+): PackageElectronBuilderOptions {
+  return {
+    root: '.',
+    platform: 'windows',
+    extraProjects: [],
+    arch: 'x64',
+    name: 'electron-app',
+    frontendProject: 'frontend',
+    prepackageOnly: false,
+    sourcePath: 'dist/apps',
+    outputPath: 'dist/packages',
+    ...overrides,
+  };
+}
 
 describe('MakeElectronBuilder', () => {
   let context: ExecutorContext;
   let options: PackageElectronBuilderOptions;
 
   beforeEach(async () => {
-    options = {
-      root: '.',
-      platform: 'windows',
-      extraProjects: [],
-      arch: 'x64',
-      name: 'electron-app',
-      frontendProject: 'frontend',
-      prepackageOnly: false,
-      sourcePath: 'dist/apps',
-      outputPath: 'dist/packages',
-    };
+    options = makeOptions();
   });
 
   describe('run', () => {
@@ -29,3 +52,199 @@ describe('MakeElectronBuilder', () => {
     });
   });
 });
+
+describe('copy step source validation', () => {
+  const existsMock = fs.existsSync as jest.Mock;
+  const context = { root: '.' } as ExecutorContext;
+
+  /** Pretends that exactly the given absolute paths exist on disk. */
+  const existing = (...paths: string[]) => {
+    const set = new Set(paths.map((path) => resolve(path)));
+    existsMock.mockImplementation((path: string) => set.has(resolve(path)));
+  };
+
+  const frontendDir = resolve('dist/apps', 'frontend');
+  const appDir = resolve('dist/apps', 'electron-app');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    existing(frontendDir, appDir);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('findMissingFileSources', () => {
+    it('reports FileSet sources that do not exist', () => {
+      const missing = resolve('dist/apps', 'does-not-exist');
+
+      expect(
+        findMissingFileSources(
+          [{ from: frontendDir, to: 'frontend' }, { from: missing, to: 'x' }],
+          makeOptions()
+        )
+      ).toEqual([missing]);
+    });
+
+    it('ignores plain string patterns, globs and macros', () => {
+      existsMock.mockReturnValue(false);
+
+      expect(
+        findMissingFileSources(
+          [
+            './package.json',
+            '!(**/*.+(js|css).map)',
+            { from: resolve('dist/apps/**/assets'), to: 'assets' },
+            { from: resolve('dist/apps/?(a|b)'), to: 'ab' },
+            { from: 'build/${os}/${arch}', to: 'bin' },
+            { to: 'no-from-means-app-dir' },
+          ],
+          makeOptions()
+        )
+      ).toEqual([]);
+      expect(existsMock).not.toHaveBeenCalled();
+    });
+
+    it('resolves extraResources / extraFiles against the workspace root', () => {
+      expect(
+        findMissingFileSources(
+          [],
+          makeOptions({
+            root: '/workspace',
+            extraResources: [
+              { from: 'assets/db', to: 'db' },
+              'assets/**/*.json',
+            ],
+            extraFiles: { from: 'bin/tool.exe', to: 'tool.exe' },
+          })
+        )
+      ).toEqual([
+        resolve('/workspace', 'assets/db'),
+        resolve('/workspace', 'bin/tool.exe'),
+      ]);
+    });
+
+    it('lists every missing source only once', () => {
+      existsMock.mockReturnValue(false);
+      const missing = resolve('dist/apps', 'shared');
+
+      expect(
+        findMissingFileSources(
+          [
+            { from: missing, to: 'a' },
+            { from: missing, to: 'b' },
+          ],
+          makeOptions()
+        )
+      ).toEqual([missing]);
+    });
+  });
+
+  describe('validateFileSources', () => {
+    it('throws a descriptive error by default', () => {
+      const missing = resolve('dist/apps', 'does-not-exist');
+
+      expect(() =>
+        validateFileSources([{ from: missing, to: 'x' }], makeOptions())
+      ).toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining(missing),
+        })
+      );
+      expect(() =>
+        validateFileSources([{ from: missing, to: 'x' }], makeOptions())
+      ).toThrow(/failOnMissingFiles/);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('only warns when failOnMissingFiles is false', () => {
+      const missing = resolve('dist/apps', 'does-not-exist');
+
+      expect(() =>
+        validateFileSources(
+          [{ from: missing, to: 'x' }],
+          makeOptions({ failOnMissingFiles: false })
+        )
+      ).not.toThrow();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect((logger.warn as jest.Mock).mock.calls[0][0]).toContain(missing);
+    });
+
+    it('does nothing when every source exists', () => {
+      expect(() =>
+        validateFileSources([{ from: frontendDir, to: 'frontend' }], makeOptions())
+      ).not.toThrow();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_createBaseConfig', () => {
+    it('fails when the frontend project has not been built', () => {
+      existing(appDir);
+
+      expect(() => _createBaseConfig(makeOptions(), context)).toThrow(
+        new RegExp(escapeRegExp(frontendDir))
+      );
+    });
+
+    it('fails when an extra project is missing', () => {
+      expect(() =>
+        _createBaseConfig(
+          makeOptions({ extraProjects: ['shared-lib'] }),
+          context
+        )
+      ).toThrow(new RegExp(escapeRegExp(resolve('dist/apps', 'shared-lib'))));
+    });
+
+    it('fails for a user supplied FileSet whose (sourcePath relative) source is missing', () => {
+      expect(() =>
+        _createBaseConfig(
+          makeOptions({
+            files: [{ from: 'worker/scripts', to: 'scripts' }],
+          }),
+          context
+        )
+      ).toThrow(
+        new RegExp(escapeRegExp(resolve('dist/apps', 'worker/scripts')))
+      );
+    });
+
+    it('succeeds when all copy step sources exist', () => {
+      const scripts = resolve('dist/apps', 'worker/scripts');
+      existing(frontendDir, appDir, scripts);
+
+      const config = _createBaseConfig(
+        makeOptions({ files: [{ from: 'worker/scripts', to: 'scripts' }] }),
+        context
+      );
+
+      expect(config.files).toEqual(
+        expect.arrayContaining([
+          { from: scripts, to: 'scripts' },
+          {
+            from: frontendDir,
+            to: 'frontend',
+            filter: ['**/!(*.+(js|css).map)'],
+          },
+        ])
+      );
+    });
+  });
+
+  describe('_createConfigFromOptions', () => {
+    it('does not leak failOnMissingFiles into the electron-builder config', () => {
+      const config = _createConfigFromOptions(
+        makeOptions({ failOnMissingFiles: false }),
+        { files: [] }
+      );
+
+      expect(config).not.toHaveProperty('failOnMissingFiles');
+    });
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/nx-electron/src/executors/package/executor.ts
+++ b/packages/nx-electron/src/executors/package/executor.ts
@@ -10,7 +10,7 @@ import {
   FileSet,
   CliOptions,
 } from 'electron-builder';
-import { writeFile, statSync, readFileSync } from 'fs';
+import { writeFile, statSync, readFileSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { promisify } from 'util';
 
@@ -35,6 +35,13 @@ export interface PackageElectronBuilderOptions extends Configuration {
   outputPath: string;
   publishPolicy?: PublishOptions['publish'];
   makerOptionsPath?: string;
+  /**
+   * Fail the packaging when the source (`from`) of a configured copy step
+   * (`files`, `extraResources`, `extraFiles`, `frontendProject`,
+   * `extraProjects`) does not exist. Defaults to `true`; set to `false` to
+   * only log a warning and let electron-builder silently skip the entry.
+   */
+  failOnMissingFiles?: boolean;
 }
 
 export interface PackageElectronBuilderOutput {
@@ -143,7 +150,7 @@ function _createTargets(
   return createTargets(platforms, null, arch);
 }
 
-function _createBaseConfig(
+export function _createBaseConfig(
   options: PackageElectronBuilderOptions,
   context: ExecutorContext
 ): Configuration {
@@ -184,6 +191,8 @@ function _createBaseConfig(
     }
   });
 
+  validateFileSources(files, options);
+
   return {
     directories: {
       ...options.directories,
@@ -206,7 +215,7 @@ function _createBaseConfig(
   };
 }
 
-function _createConfigFromOptions(
+export function _createConfigFromOptions(
   options: PackageElectronBuilderOptions,
   baseConfig: Configuration
 ): Configuration {
@@ -225,8 +234,92 @@ function _createConfigFromOptions(
   delete config.sourcePath;
   delete config.outputPath;
   delete config['makerOptionsPath'];
+  delete config['failOnMissingFiles'];
 
   return config;
+}
+
+/** Matches glob syntax and electron-builder `${macro}` expansions. */
+const NON_LITERAL_PATH = /[*?[\]{}!]|\$\{/;
+
+function isLiteralPath(from: unknown): from is string {
+  return (
+    typeof from === 'string' && from.length > 0 && !NON_LITERAL_PATH.test(from)
+  );
+}
+
+function toArray<T>(value: T | T[] | null | undefined): T[] {
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Collects the absolute `from` paths of all explicitly configured copy steps
+ * (`files` FileSets — including the ones derived from `frontendProject` and
+ * `extraProjects` — as well as top-level `extraResources` / `extraFiles`)
+ * whose source does not exist on disk.
+ *
+ * `files` entries are expected to be resolved already (see
+ * `_createBaseConfig`); `extraResources` / `extraFiles` are resolved against
+ * the workspace root, which is what electron-builder uses as project directory.
+ * Plain string patterns, globs and entries containing macros are ignored since
+ * their existence cannot be determined statically.
+ */
+export function findMissingFileSources(
+  files: Array<FileSet | string>,
+  options: PackageElectronBuilderOptions
+): string[] {
+  const sources = new Set<string>();
+
+  files.forEach((file) => {
+    if (file && typeof file === 'object' && isLiteralPath(file.from)) {
+      sources.add(file.from);
+    }
+  });
+
+  (['extraResources', 'extraFiles'] as const).forEach((key) => {
+    toArray(options[key]).forEach((entry) => {
+      if (entry && typeof entry === 'object' && isLiteralPath(entry.from)) {
+        sources.add(resolve(options.root, entry.from));
+      }
+    });
+  });
+
+  return Array.from(sources).filter((source) => !existsSync(source));
+}
+
+/**
+ * electron-builder silently skips (debug log only) `files` entries whose
+ * `from` directory does not exist and merely warns for `extraResources` /
+ * `extraFiles`. A typo in a path or a forgotten build step therefore yields a
+ * "successful" artifact that is missing assets. Fail loudly instead, unless
+ * `failOnMissingFiles` is explicitly set to `false`.
+ */
+export function validateFileSources(
+  files: Array<FileSet | string>,
+  options: PackageElectronBuilderOptions
+): void {
+  const missing = findMissingFileSources(files, options);
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  const message = [
+    'The following copy step source(s) configured for packaging do not exist:',
+    ...missing.map((source) => `  - ${source}`),
+    'Make sure the referenced projects / assets have been built before packaging, or fix the "from" path(s).',
+    'Set "failOnMissingFiles": false to downgrade this error to a warning.',
+  ].join('\n');
+
+  if (options.failOnMissingFiles === false) {
+    logger.warn(message);
+    return;
+  }
+
+  throw new Error(message);
 }
 
 function _normalizeBuilderOptions(

--- a/packages/nx-electron/src/executors/package/schema.json
+++ b/packages/nx-electron/src/executors/package/schema.json
@@ -87,6 +87,11 @@
     "makerOptionsPath": {
       "type": "string",
       "description": "Overrides the '{sourceRoot}/app/options/maker.options.json' configuration file path."
+    },
+    "failOnMissingFiles": {
+      "type": "boolean",
+      "description": "Fail the packaging when the source ('from') of a configured copy step ('files', 'extraResources', 'extraFiles', 'frontendProject', 'extraProjects') does not exist. Set to false to only log a warning and let electron-builder silently skip the entry.",
+      "default": true
     }
   },
   "required": [


### PR DESCRIPTION
## Problem

The maker / package options allow adding copy steps (electron-builder `files` FileSets, `extraResources`, `extraFiles`, plus nx-electron's own `frontendProject` / `extraProjects`) to include additional JS files or assets in the packaged app.

When the source (`from`) of such a copy step does not exist, the packaging still **succeeds**:

- nx-electron's `_createBaseConfig` only resolves the `from` paths and hands them to electron-builder without any validation.
- electron-builder (app-builder-lib `appFileCopier.computeFileSets`) `stat`s each `files` matcher and, if the source is missing, logs `skipped copying … doesn't exist` at **debug** level and continues. `extraResources` / `extraFiles` (`fileMatcher.copyFiles`) only emit a warning.

So a typo in a `from` path, or a frontend / extra project that has not been built yet, produces a "successful" artifact that is silently missing assets — usually only discovered at runtime.

## Solution

The package executor now validates every explicitly configured copy step source before invoking electron-builder:

- `files` FileSets (resolved relative to `sourcePath`, including the FileSets derived from `frontendProject` and `extraProjects`)
- top-level `extraResources` / `extraFiles` FileSets (resolved relative to the workspace root, electron-builder's project dir)

If any source is missing, the target fails with an error listing all missing absolute paths:

```
The following copy step source(s) configured for packaging do not exist:
  - D:\ws\dist\apps\frontend
  - D:\ws\dist\apps\worker\scripts
Make sure the referenced projects / assets have been built before packaging, or fix the "from" path(s).
Set "failOnMissingFiles": false to downgrade this error to a warning.
```

Plain string patterns, globs and entries containing `${macro}` expansions are not checked, since their existence cannot be determined statically.

A new executor option `failOnMissingFiles` (default `true`) restores the previous lenient behaviour when set to `false` — the missing sources are then only logged as a warning. The option is stripped from the config before it is passed to electron-builder, so its schema validation is unaffected. It can be set as target option or inside `maker.options.json`.

## Changes

- `executors/package/executor.ts`: `findMissingFileSources` / `validateFileSources`, wired into `_createBaseConfig`; `failOnMissingFiles` option
- `executors/package/schema.json`: new `failOnMissingFiles` option
- `executors/package/executor.spec.ts`: unit tests for missing / existing sources, glob & macro handling, `extraResources` / `extraFiles` resolution, warning mode and option stripping
- `docs/packaging.md`: new "Copy steps and missing sources" section

## Notes

- Behaviour change: packaging with a missing copy step source now fails by default. Users relying on optional directories can opt out with `failOnMissingFiles: false`.
- Independent of #386 (Nx v23 update); based on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
